### PR TITLE
setup ci

### DIFF
--- a/.github/workflows/prsteps.yml
+++ b/.github/workflows/prsteps.yml
@@ -1,0 +1,27 @@
+name: prsteps
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  execute:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Install prsteps
+        run: go install github.com/knightso/prsteps@latest
+      - name: Execute
+        run: prsteps ${{github.repository}} ${{github.event.number}}

--- a/.github/workflows/prsteps.yml
+++ b/.github/workflows/prsteps.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Install prsteps
         run: go install github.com/knightso/prsteps@latest
       - name: Execute
-        run: prsteps ${{github.repository}} ${{github.event.number}}
+        run: prsteps -pat ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.event.number }}


### PR DESCRIPTION
## 概要

PR が merge された時に prsteps を走らせるような CI を記述しました

## 確認方法

[act](https://github.com/nektos/act) コマンドを使用します

1. `pr.json` を作成

```
{
    "pull_request": {
      "merged": true
    }
}
```

2. `.github/workflows/prsteps.yml` を修正

ローカルの act で go install をする際に `x509: certificate signed by unknown authority` が発生してしまうため、以下の step を追加します。

```diff
          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
          restore-keys: |
            ${{ runner.os }}-go-
+     - name: Install ca-certificates
+       run: apt-get update && apt-get install -y --no-install-recommends ca-certificates
      - uses: actions/setup-go@v4
        with:
          go-version-file: go.mod
```

3. act を実行

失敗はしますが、PR が merge されたというイベントが発生した際に CI が走り、prsteps まで到達していることが確認できます。

```shell
$ act -W .github/workflows/prsteps.yml pull_request -e pr.json
.
.
| requires exactly 2 argument.
| Usage: prsteps [OPTIONS] REPO PR
|   -format string
|       Format output(csv, tsv) (default "csv")
|   -pat string
|       GitHub Private Access Tokens(for accessing private repositories)
|   -version
|       Print version information and quit
[prsteps/execute]   ❌  Failure - Main Execute
[prsteps/execute] exitcode '1': failure
[prsteps/execute] 🏁  Job failed
Error: Job 'execute' failed
```